### PR TITLE
fix: Remove dependency not used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ requires-python = ">3.10"
 dependencies = [
     "requests==2.32.5",
     "click==8.1.8",
-    "click-extra==4.15.0",
     "rich==14.1.0",
     "rich-click==1.8.9",
     "prompt_toolkit==3.0.51",


### PR DESCRIPTION
Removing click-extra, it is not used anywhere.

Fixes: https://github.com/ewcloud/ewccli/issues/6
Related-To: https://github.com/ewcloud/ewccli/issues/10