### PR TITLE
fix: add missing default mandatory value

### DIFF
--- a/ewccli/commands/hub/hub_backends.py
+++ b/ewccli/commands/hub/hub_backends.py
@@ -33,6 +33,10 @@ HUB_ENV_VARIABLES_MAP = {
         Federee.ECMWF.value: ["192.168.1.0/24"],
         Federee.EUMETSAT.value: ["10.0.0.0/24"],
     },
+    "fail2ban_whitelisted_ip_ranges": {
+        Federee.ECMWF.value: ["192.168.1.0/24"],
+        Federee.EUMETSAT.value: ["10.0.0.0/24"],
+    },
     "whitelisted_ip_ranges": {
         Federee.ECMWF.value: ["192.168.1.0/24"],
         Federee.EUMETSAT.value: ["10.0.0.0/24"],


### PR DESCRIPTION
ssh-proxy fails because the default mandatory value is not passed