### PR TITLE
feat: improve --image-name help message with examples

### DIFF
--- a/ewccli/commands/commons.py
+++ b/ewccli/commands/commons.py
@@ -236,7 +236,7 @@ def openstack_optional_options(func):
         envvar="EWC_CLI_OPENSTACK_IMAGE_NAME",
         show_default=True,
         type=str,
-        help="Select image name to be used. (or set env var EWC_CLI_OPENSTACK_IMAGE_NAME)",
+        help="Select image name to be used. (or set env var EWC_CLI_OPENSTACK_IMAGE_NAME)\nExamples: --image-name Ubuntu-22.04 or --image-name Rocky-9 or --image-name Rocky-9-GPU",
     )(func)
     func = click.option(
         "--flavour-name",


### PR DESCRIPTION
## Summary

Improve the help message for the `--image-name` flag to include example valid inputs, as suggested in PR #70 review.

## Changes

Update the help text in `ewccli/commands/commons.py` to include:



This helps users understand what valid image names they can use.

Closes #77