### PR TITLE
fix: bump requires-python to >=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file = "LICENSE" }
 maintainers = [
   { name = "EWC", email = "support@europeanweather.cloud"}
 ]
-requires-python = ">3.10"
+requires-python = ">=3.11"
 dependencies = [
     "requests==2.32.5",
     "click==8.3.0",


### PR DESCRIPTION
## Problem

`uv sync` fails with an unsatisfiable dependency error because `requires-python = ">3.10"` allows Python 3.10.x versions, but `ansible==11.8.0` requires Python >= 3.11.

## Fix

Change `requires-python` from `">3.10"` to `">=3.11"` to match the minimum Python version supported by our dependencies.