### PR TITLE
test: introduce CLI commmands test

### DIFF
--- a/ewccli/commands/commons_infra.py
+++ b/ewccli/commands/commons_infra.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 from rich import box
-import click
+
 from click import ClickException
 from openstack import connection
 
@@ -36,8 +36,13 @@ console = Console()
 def check_user_ssh_keys(
     ssh_public_key_path: Optional[str] = None,
     ssh_private_key_path: Optional[str] = None,
+    dry_run: bool = False
 ):
     """Check if SSH keys are compatible or missing."""
+    if dry_run:
+        _LOGGER.info("Dry Run enable: Skipping checking SSH private and public keys...")
+        return
+
     # If still missing, raise exception
     missing_ssh_keys = []
     if not ssh_public_key_path:
@@ -598,7 +603,7 @@ def deploy_server(
     outputs: dict[str, Optional[str]] = {}
 
     if dry_run:
-        return 0, "dru run enabled.", outputs
+        return 0, "Dry run: skipping deploy server...", outputs
 
     server_name: str = server_inputs["server_name"]
     keypair_name: str = server_inputs["keypair_name"]

--- a/ewccli/commands/hub/hub_backends.py
+++ b/ewccli/commands/hub/hub_backends.py
@@ -164,6 +164,9 @@ def git_clone_item(
     ########################################################################
     # Prepare input for items
     ########################################################################
+    if dry_run:
+        return 0, "Dry run: skipping git clone..."
+
     _LOGGER.info("Git clone item...")
     ########################################################################
     # Git clone item to the correct path

--- a/ewccli/commands/hub/hub_command.py
+++ b/ewccli/commands/hub/hub_command.py
@@ -294,9 +294,9 @@ def _validate_item(ctx, param, value):
     is_flag=False,
     required=False,
     default=None,
-    envvar="EWC_CLI_INSTANCE_NAME",
+    envvar="EWC_CLI_SERVER_NAME",
     show_default=False,
-    help="Select a name for the server.",
+    help="Select a name for the server. (or set env var EWC_CLI_SERVER_NAME)",
 )
 @click.option(
     "--item-inputs",
@@ -366,16 +366,20 @@ def deploy_cmd(  # noqa: CFQ002, CFQ001, CCR001, C901
         _LOGGER.info("Dry run enabled...")
 
     if profile:
-        cli_profile = load_cli_profile(profile=profile)
+        cli_profile = load_cli_profile(
+            profile=profile,
+            dry_run=dry_run
+        )
     else:
         # Use default profile if exists
         cli_profile = load_cli_profile(
-            profile=ewc_hub_config.EWC_CLI_DEFAULT_PROFILE_NAME
+            profile=ewc_hub_config.EWC_CLI_DEFAULT_PROFILE_NAME,
+            dry_run=dry_run
         )
 
     _LOGGER.info(f"Using `{cli_profile.get('profile')}` profile.")
 
-    tenancy_name = cli_profile["tenant_name"]
+    tenancy_name: str = cli_profile["tenant_name"]
     federee: str = cli_profile["federee"]
 
     # Try to fill from CLI profile if not provided
@@ -387,7 +391,8 @@ def deploy_cmd(  # noqa: CFQ002, CFQ001, CCR001, C901
 
     check_user_ssh_keys(
         ssh_public_key_path=ssh_public_key_path,
-        ssh_private_key_path=ssh_private_key_path
+        ssh_private_key_path=ssh_private_key_path,
+        dry_run=dry_run
     )
 
     # Take item information
@@ -527,6 +532,10 @@ def deploy_cmd(  # noqa: CFQ002, CFQ001, CCR001, C901
         )
         if not auth_url:
             auth_url = ewc_hub_config.EWC_CLI_SITE_MAP.get(federee)
+
+        if dry_run:
+            console.print(Panel(f"Dry run: skipping OpenStack connection and exiting.", title="Info", style="green"))
+            sys.exit(0)
 
         try:
             openstack_backend = OpenstackBackend(

--- a/ewccli/tests/ewccli_cli_hub_deploy_test.py
+++ b/ewccli/tests/ewccli_cli_hub_deploy_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+#
+# Package Name: ewccli
+# License: GPL-3.0-or-later
+# Copyright (c) 2026 EUMETSAT, ECMWF for European Weather Cloud
+# See the LICENSE file for more details
+
+import pytest
+from click.testing import CliRunner
+from unittest.mock import patch, MagicMock
+
+from ewccli.ewccli import cli
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+# -----------------------------
+# VALID SSH KEY FIXTURES
+# -----------------------------
+@pytest.fixture
+def valid_private_key_pem() -> str:
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives import serialization
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode("utf-8")
+
+
+@pytest.fixture
+def valid_public_key_openssh(valid_private_key_pem: str) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    private_key = serialization.load_pem_private_key(
+        valid_private_key_pem.encode("utf-8"), password=None
+    )
+    pub = private_key.public_key()
+    return pub.public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    ).decode("utf-8")
+
+
+# -----------------------------
+# Mock profile loader globally
+# -----------------------------
+@pytest.fixture(autouse=True)
+def mock_profile_loader(tmp_path, valid_private_key_pem, valid_public_key_openssh):
+    pub_key = tmp_path / "id_rsa.pub"
+    priv_key = tmp_path / "id_rsa"
+
+    # ✅ write VALID keys
+    pub_key.write_text(valid_public_key_openssh)
+    priv_key.write_text(valid_private_key_pem)
+
+    with patch("ewccli.commands.hub.hub_command.load_cli_profile") as mock_load:
+        mock_load.return_value = {
+            "profile": "test-profile",
+            "auth_url": "http://fake-auth-url",
+            "application_credential_id": "fake-id",
+            "application_credential_secret": "fake-secret",
+            "tenant_name": "test-tenant",
+            "federee": "test-federee",
+            "ssh_public_key_path": str(pub_key),
+            "ssh_private_key_path": str(priv_key),
+        }
+        yield mock_load
+
+
+# -----------------------------
+# Mock ctx.obj (CRITICAL)
+# -----------------------------
+@pytest.fixture(autouse=True)
+def mock_ctx_obj():
+    with patch("ewccli.commands.hub.hub_command.categorize_item_inputs") as m1, \
+         patch("ewccli.commands.hub.hub_command.check_missing_required_inputs") as m2:
+
+        m1.return_value = ([], [])
+        m2.return_value = []
+
+        yield
+
+
+# -----------------------------
+# CLI tests
+# -----------------------------
+def test_deploy_help(runner):
+    result = runner.invoke(cli, ["hub", "deploy", "--help"])
+    assert result.exit_code == 0
+
+
+def test_deploy_missing_item(runner):
+    result = runner.invoke(cli, ["hub", "deploy"])
+    assert result.exit_code != 0
+
+
+def test_deploy_dry_run_minimal(runner):
+    result = runner.invoke(
+        cli,
+        ["hub", "deploy", "ssh-bastion-flavour", "--dry-run"],
+        obj={
+            "items": {
+                "ssh-bastion-flavour": {
+                    "cli": {"inputs": []}
+                }
+            }
+        },
+    )
+    print(result.output)
+    print(result.exception)
+
+    assert result.exit_code == 0
+
+
+def test_deploy_with_ssh_paths(runner, tmp_path, valid_private_key_pem, valid_public_key_openssh):
+    pub_key = tmp_path / "id_rsa.pub"
+    priv_key = tmp_path / "id_rsa"
+
+    pub_key.write_text(valid_public_key_openssh)
+    priv_key.write_text(valid_private_key_pem)
+
+    result = runner.invoke(
+        cli,
+        [
+            "hub",
+            "deploy",
+            "ssh-bastion-flavour",
+            "--ssh-public-key-path",
+            str(pub_key),
+            "--ssh-private-key-path",
+            str(priv_key),
+            "--dry-run",
+        ],
+        obj={
+            "items": {
+                "ssh-bastion-flavour": {
+                    "cli": {"inputs": []}
+                }
+            }
+        },
+    )
+
+    assert result.exit_code == 0
+
+
+def test_deploy_with_env_vars(runner, tmp_path, valid_private_key_pem, valid_public_key_openssh):
+    pub_key = tmp_path / "id_rsa.pub"
+    priv_key = tmp_path / "id_rsa"
+
+    pub_key.write_text(valid_public_key_openssh)
+    priv_key.write_text(valid_private_key_pem)
+
+    result = runner.invoke(
+        cli,
+        ["hub", "deploy", "ssh-bastion-flavour", "--dry-run"],
+        env={
+            "EWC_CLI_SSH_PUBLIC_KEY_PATH": str(pub_key),
+            "EWC_CLI_SSH_PRIVATE_KEY_PATH": str(priv_key),
+        },
+        obj={
+            "items": {
+                "ssh-bastion-flavour": {
+                    "cli": {"inputs": []}
+                }
+            }
+        },
+    )
+
+    assert result.exit_code == 0

--- a/ewccli/utils.py
+++ b/ewccli/utils.py
@@ -184,6 +184,7 @@ def load_cli_profile(
     federee: Optional[str] = None,
     tenant_name: Optional[str] = None,
     profiles_file_path: Path = ewc_hub_config.EWC_CLI_PROFILES_PATH,
+    dry_run: bool = False
 ) -> Dict[str, Optional[str]]:
     """
     Load all profile data (config + credentials) from the single profiles file.
@@ -209,6 +210,9 @@ def load_cli_profile(
     click.Abort
         If the profile cannot be found or cannot be resolved.
     """
+    if dry_run:
+        return {}
+
     if profile is None:
         if not federee or not tenant_name:
             click.secho(


### PR DESCRIPTION
This PR refactor some methods and code to allow proper testing of the CLI commands. Including when dry_run is enabled.

- [x] allow dry run
- [x] add tests

```
((newtestewccli) ) murdaca@fra-dev-new:~/work-ewc/ewccli-github$ ewc hub deploy --help
                                                                                                                                                                                                      
 Usage: ewc hub deploy [OPTIONS] ITEM                                                                                                                                                                 
                                                                                                                                                                                                      
 Deploy EWC Hub item.                                                                                                                                                                                 
 ewc hub deploy <item>                                                                                                                                                                                
 where <item> is taken from ewc hub list command (under Item column)                                                                                                                                  
                                                                                                                                                                                                      
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --ssh-private-key-path                 TEXT       Path to SSH private key. (or set env var EWC_CLI_SSH_PRIVATE_KEY_PATH)                                                                           │
│ --ssh-public-key-path                  TEXT       Path to SSH public key. (or set env var EWC_CLI_SSH_PUBLIC_KEY_PATH)                                                                             │
│ --ssh-public-encoded                   TEXT       Base64 encoded SSH public key. (or set env var EWC_CLI_ENCODED_SSH_PUBLIC_KEY)                                                                   │
│ --ssh-private-encoded                  TEXT       Base64 encoded SSH private key. (or set env var EWC_CLI_ENCODED_SSH_PRIVATE_KEY)                                                                 │
│ --application-credential-secret        TEXT       Openstack Application Credentials Secret. (or set env var OS_APPLICATION_CREDENTIAL_SECRET)                                                      │
│ --application-credential-id            TEXT       Openstack Application Credentials ID. (or set env var OS_APPLICATION_CREDENTIAL_ID)                                                              │
│ --auth-url                       -url  TEXT       Openstack Auth URL. (or set env var OS_AUTH_URL)                                                                                                 │
│ --external-ip                                     Add External IP to the machine.                                                                                                                  │
│ --flavour-name                   -fr   TEXT       Select a name for the keypair in Openstack. (or set env var EWC_CLI_OPENSTACK_FLAVOUR_NAME)                                                      │
│ --image-name                     -ig   TEXT       Select image name to be used. (or set env var EWC_CLI_OPENSTACK_IMAGE_NAME)                                                                      │
│ --keypair-name                   -kp   TEXT       Select a name for the keypair in Openstack. (or set env var EWC_CLI_OPENSTACK_KEYPAIR_NAME) [default: (murdaca-ewccli-keypair)]                  │
│ --security-groups                -sg   TEXT       List of security groups (comma-separated in env var EWC_CLI_OPENSTACK_SECURITY_GROUPS or multiple arguments with the flag).                      │
│ --networks                       -n    TEXT       List of networks (comma-separated in env var EWC_CLI_OPENSTACK_NETWORKS or multiple arguments with the flag).                                    │
│ --server-name                          TEXT       Select a name for the server. (or set env var EWC_CLI_SERVER_NAME)                                                                               │
│ --item-inputs                    -iu   KEY=VALUE  Provide item input as key=value. May be passed multiple times.                                                                                   │
│                                                   Examples:   --item-inputs key1=value1   --item-inputs retries=3   --item-inputs names="['a', 'b']"                                               │
│                                                   Note:   When passing lists or dictionaries, the syntax used to parse inputs is same as yaml.                                                     │
│ --dry-run                                         Simulate deployment without running.                                                                                                             │
│ --profile                              TEXT       EWC CLI profile name                                                                                                                             │
│ --force                                           Force item recreation operation.                                                                                                                 │
│ --help                           -h               Show this message and exit.                                                                                                                      │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```