### PR TITLE
ci: Semantic release on demand only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,7 @@
 name: Semantic Release
 
 on:
-  push:
-    branches:
-      - main
-
-  ## TODO: Uncomment lines below an replace the above on.push trigger once linting checks pass (see https://github.com/ewcloud/ewccli/pull/108)
-  #workflow_run:
-  #  workflows: ["Linting and Unittesting"]
-  #  types:
-  #    - completed
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -19,9 +11,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    
-    ## TODO: Uncomment line below once linting checks pass (see https://github.com/ewcloud/ewccli/pull/108)
-    # if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     steps:
       - name: Generate token for EWC Semantic Releaser GitHub App

--- a/.releaserc
+++ b/.releaserc
@@ -37,7 +37,7 @@
         [
             "@semantic-release/git",
             {
-                "assets": ["CHANGELOG.md"],
+                "assets": ["CHANGELOG.md", "pyproject.toml", "ewccli/__init__.py"],
                 "message": "chore: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
             }
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,6 @@ All notable changes to this project are documented in this file. See
 
 * Introduce region parameter ([#116](https://github.com/ewcloud/ewccli/issues/116)) ([70d2920](https://github.com/ewcloud/ewccli/commit/70d29204ce78c3c945063b7a93d5246ea60fc938))
 
-# Changelog
-
-All notable changes to this project are documented in this file.
-
-
 # 0.3.2
 
 ### Bug Fixes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,17 @@
 # Releasing ewccli
 
 ## Before you begin
-Make sure to pull the latest code and checkout the correct tag (in semantic version format `x.y.x`):
+
+### 1. Trigger the CI to update of CHANGELOG.md and git tags
+> 💡 The CI only makes changes only if new [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) of type `feat` and `fix` added to the main branch since the last `git tag` was created.
+
+Ensure that all pull requests relevant for the next release have been merged before triggering the [Semantic Release GitHub Action](https://github.com/ewcloud/ewccli/actions/workflows/release.yml).
+
+
+After CI completion, verify a new tag (in semantic version format `x.y.z`) is created on the main branch, and the [CHANGELOG.md](./CHANGELOG.md) reflects the relevant features/fixes as they appear in the commit history.
+
+### 2. Pull the latest code chances
+Make sure to pull the latest code and checkout the correct tag (in semantic version format `x.y.z`):
 
 ```bash
 git checkout main


### PR DESCRIPTION
Hello @pacospace,

This PR modifies  the behavior of the [Semantic Release GitHub Action](https://github.com/ewcloud/ewccli/actions/workflows/release.yml) so that it does not trigger automatically after every PR merge to main.

Now manual trigger is needed. This is documented as apart of RELEASING.md now.