### PR TITLE
fix: AttributeError: 'dict' object has no attribute 'federee'

### DIFF
--- a/ewccli/commands/infra_command.py
+++ b/ewccli/commands/infra_command.py
@@ -141,8 +141,8 @@ def create_cmd(
         _LOGGER.info("Dry run enabled...")
 
     cli_profile = ctx.cli_profile
-    federee = federee or cli_profile.federee
-    region = region or cli_profile.region
+    federee = federee or cli_profile["federee"]
+    region = region or cli_profile["region"]
 
     allowed_regions = ewc_hub_config.allowed_regions(federee)
     if region not in allowed_regions:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/bin/ewc", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/rich_click/rich_command.py", line 402, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/rich_click/rich_command.py", line 216, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/click/decorators.py", line 93, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/newtestewccli/lib/python3.12/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/murdaca/work-ewc/ewccli-github/ewccli/commands/infra_command.py", line 145, in create_cmd
    federee = federee or cli_profile.federee
                         ^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'federee'
```