### PR TITLE
fix: compare security groups order-insensitively

### DIFF
--- a/ewccli/commands/commons_infra.py
+++ b/ewccli/commands/commons_infra.py
@@ -106,9 +106,12 @@ def check_server_conflict_with_inputs(
             return ", ".join(server_info.addresses.keys())
         return ""
 
-    def _get_security_groups_string(server_info):
+    def _get_security_group_names(server_info):
         groups = getattr(server_info, "security_groups", [])
-        return ",".join(sg.get("name") for sg in groups)
+        return [
+            sg.get("name") if hasattr(sg, "get") else getattr(sg, "name", None)
+            for sg in groups
+        ]
 
     if image_name and server_info_image:
         compare("Image", image_name, server_info_image)
@@ -128,11 +131,15 @@ def check_server_conflict_with_inputs(
         compare("Network", ",".join(networks), _get_network_names(server_info))
 
     if security_groups:
-        compare(
-            "Security Groups",
-            ",".join(security_groups),
-            _get_security_groups_string(server_info),
-        )
+        actual_security_groups = _get_security_group_names(server_info)
+        if sorted(actual_security_groups) != sorted(security_groups):
+            diffs.append(
+                (
+                    "Security Groups",
+                    ",".join(actual_security_groups),
+                    ",".join(security_groups),
+                )
+            )
 
     return diffs
 

--- a/ewccli/tests/ewccli_commands_common_infra_test.py
+++ b/ewccli/tests/ewccli_commands_common_infra_test.py
@@ -27,6 +27,7 @@ from ewccli.commands.commons_infra import pre_deploy_server_setup
 from ewccli.commands.commons_infra import identify_server_reconfiguration
 from ewccli.commands.commons_infra import deploy_server
 from ewccli.commands.commons_infra import post_deploy_server_setup
+from ewccli.commands.commons_infra import check_server_conflict_with_inputs
 
 
 
@@ -450,6 +451,44 @@ def test_identify_server_reconfiguration_wrong_origin(conn):
     assert "not been deployed with the EWC CLI" in msg
     assert outputs == {}
 
+
+def test_check_server_conflict_security_groups_order_insensitive():
+    server_info = MagicMock()
+    server_info.security_groups = [
+        {"name": "http-https-only"},
+        {"name": "8080"},
+        {"name": "ssh"},
+    ]
+
+    diffs = check_server_conflict_with_inputs(
+        server_info,
+        security_groups=("ssh", "http-https-only", "8080"),
+    )
+
+    assert diffs == []
+
+
+def test_check_server_conflict_security_groups_reports_real_mismatch():
+    server_info = MagicMock()
+    server_info.security_groups = [
+        {"name": "http-https-only"},
+        {"name": "8080"},
+    ]
+
+    diffs = check_server_conflict_with_inputs(
+        server_info,
+        security_groups=("ssh", "http-https-only", "8080"),
+    )
+
+    assert diffs == [
+        (
+            "Security Groups",
+            "http-https-only,8080",
+            "ssh,http-https-only,8080",
+        )
+    ]
+
+
 def test_deploy_server_success(conn):
     backend = MagicMock()
 
@@ -636,4 +675,3 @@ def test_create_server_command_success(conn):
     mock_pre.assert_called_once()
     mock_identify.assert_called_once()
     mock_deploy.assert_called_once()
-    


### PR DESCRIPTION
Fixes #68.

This updates the server conflict check so security group names are compared order-insensitively. Real security group mismatches still report the observed and requested values in their original order.

Validation:
- `. .venv/bin/activate && pytest ewccli/tests/ewccli_commands_common_infra_test.py -q`
  - `20 passed in 0.85s`
- `. .venv/bin/activate && pytest -q`
  - `104 passed, 5 warnings in 5.14s`
- `git diff --check`
  - Passed with no output.
